### PR TITLE
Add lab upgrade buttons

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -31,6 +31,8 @@ async def main():
     dp.include_router(start_router)
     from handlers.lab.status import router as lab_status_router
     dp.include_router(lab_status_router)
+    from handlers.lab.skills import router as lab_skills_router
+    dp.include_router(lab_skills_router)
 
     # TODO: подключите сюда остальные роутеры, например:
     # from handlers.lab.status import router as lab_status_router

--- a/handlers/lab/skills.py
+++ b/handlers/lab/skills.py
@@ -1,1 +1,36 @@
-    
+from aiogram import Router, types, F
+from tortoise.exceptions import DoesNotExist
+
+from services.lab_service import (
+    get_player_cached,
+    get_lab_cached,
+    get_skill_cached,
+)
+
+router = Router()
+
+@router.callback_query(F.data.startswith("upgrade:"))
+async def upgrade_skill(callback: types.CallbackQuery):
+    user_id = callback.from_user.id
+    try:
+        player = await get_player_cached(user_id)
+    except DoesNotExist:
+        return await callback.answer("Сначала отправьте /start", show_alert=True)
+
+    lab = await get_lab_cached(player)
+    skills = await get_skill_cached(lab)
+
+    _, field = callback.data.split(":", 1)
+
+    if field == "pathogen":
+        lab.max_pathogens += 1
+        lab.free_pathogens += 1
+        await lab.save()
+    else:
+        value = getattr(skills, field, None)
+        if value is None:
+            return await callback.answer("Неизвестный параметр", show_alert=True)
+        setattr(skills, field, value + 1)
+        await skills.save()
+
+    await callback.answer("Улучшено")

--- a/handlers/lab/status.py
+++ b/handlers/lab/status.py
@@ -15,6 +15,7 @@ from services.lab_service import (
 )
 
 from models.pathogen import Pathogen
+from keyboards.lab_kb import lab_keyboard
 
 router = Router()
 
@@ -42,11 +43,14 @@ async def cmd_lab_status(message: types.Message):
 
     # 4) Данные корпорации
     if lab.corporation:
-        corp_name  = lab.corporation.name
+        corp_name = lab.corporation.name
         corp_tg_id = lab.corporation.tg_id
+        corp_line = (
+            f"🏢 В составе корпорации: "
+            f"«<a href=\"tg://openmessage?user_id={corp_tg_id}\">{corp_name}</a>»\n\n"
+        )
     else:
-        corp_name  = "—"
-        corp_tg_id = user_id
+        corp_line = ""
 
     # 5) Активность
     blocks = "▪️" * max(1, lab.activity // 20)
@@ -70,8 +74,7 @@ async def cmd_lab_status(message: types.Message):
     text = (
         f"<b>🔬 Лаборатория игрока:</b> "
         f"<a href=\"tg://openmessage?user_id={user_id}\">[🎪] {message.from_user.full_name}</a>\n"
-        f"🏢 В составе корпорации: "
-        f"«<a href=\"tg://openmessage?user_id={corp_tg_id}\">{corp_name}</a>»\n\n"
+        f"{corp_line}"
 
         f"<b>🔋 Активность: [{blocks}] {lab.activity}%</b>\n"
         f"<blockquote>Майнинг +{lab.mining_bonus}% 💎 | Премия +{lab.premium_bonus}% 🧬</blockquote>\n"
@@ -97,4 +100,4 @@ async def cmd_lab_status(message: types.Message):
         f"😨 Своих болезней: {stats.own_diseases}</b>"
     )
 
-    await message.answer(text)
+    await message.answer(text, reply_markup=lab_keyboard())

--- a/keyboards/lab_kb.py
+++ b/keyboards/lab_kb.py
@@ -1,0 +1,16 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
+
+
+def lab_keyboard() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    # First row
+    builder.button(text="🧪", callback_data="upgrade:pathogen")
+    builder.button(text="👩\u200d🔬", callback_data="upgrade:qualification")
+    builder.button(text="🦠", callback_data="upgrade:infectivity")
+    # Second row
+    builder.button(text="🛡", callback_data="upgrade:immunity")
+    builder.button(text="💀", callback_data="upgrade:lethality")
+    builder.button(text="🕵", callback_data="upgrade:safety")
+    builder.adjust(3, 3)
+    return builder.as_markup()


### PR DESCRIPTION
## Summary
- add inline keyboard for lab upgrades
- handle upgrades via callback queries
- show corporation info only when a lab is in a corporation

## Testing
- `python -m py_compile bot.py handlers/lab/skills.py handlers/lab/status.py keyboards/lab_kb.py`


------
https://chatgpt.com/codex/tasks/task_e_687a6e404c1c832abf848eae478624d6