### PR TITLE
Add admin resource boost and multi-level upgrades

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -33,6 +33,8 @@ async def main():
     dp.include_router(lab_status_router)
     from handlers.lab.skills import router as lab_skills_router
     dp.include_router(lab_skills_router)
+    from handlers.admin import router as admin_router
+    dp.include_router(admin_router)
 
     # TODO: подключите сюда остальные роутеры, например:
     # from handlers.lab.status import router as lab_status_router

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,0 +1,42 @@
+from aiogram import Router, types, F
+import re
+
+from models.player import Player
+from services.lab_service import get_lab_cached
+from models.statistics import Statistics
+
+ADMIN_IDS = {1806169479, 1194325722}
+
+router = Router()
+
+@router.message(F.text.regexp(r"^\.буст\s+(\d+)\s+(\S+)", flags=re.IGNORECASE))
+async def cmd_boost(message: types.Message, regexp: re.Match):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+
+    amount = int(regexp.group(1))
+    user_ref = regexp.group(2)
+
+    target_id = None
+    if user_ref.startswith("@"):
+        try:
+            chat = await message.bot.get_chat(user_ref)
+            target_id = chat.id
+        except Exception:
+            return await message.answer("Не удалось определить пользователя")
+    else:
+        try:
+            target_id = int(user_ref)
+        except ValueError:
+            return await message.answer("Неверный формат пользователя")
+
+    player = await Player.get_or_none(telegram_id=target_id)
+    if not player:
+        return await message.answer("Игрок не найден")
+
+    lab = await get_lab_cached(player)
+    stats = await Statistics.get(lab=lab)
+    stats.bio_resource += amount
+    await stats.save()
+
+    await message.answer(f"Выдано {amount} био-ресурсов пользователю {user_ref}")


### PR DESCRIPTION
## Summary
- add `.буст` command for admins to grant bio-resource to players
- enhance lab skills to support variable upgrades via text commands
- register the new admin router

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687aa3b7e7cc832aa722abc3c4f2d012