### PR TITLE
Add pathogen production with qualification cap

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -6,6 +6,7 @@ from tortoise.exceptions import DoesNotExist
 from models.player import Player
 from services.lab_service import get_lab_cached
 from models.statistics import Statistics
+from utils.formatting import short_number
 
 ADMIN_IDS = {1806169479, 1194325722}
 router = Router()
@@ -46,6 +47,6 @@ async def cmd_boost(message: types.Message):
     await stats.save()
 
     await message.answer(
-        f"✅ Админ выдал {amount} био‑ресурсов игроку "
+        f"✅ Админ выдал {short_number(amount)} био‑ресурсов игроку "
         f"<b>{player.username or player.telegram_id}</b>"
     )

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -2,6 +2,8 @@
 from aiogram import Router, types
 from aiogram.filters import CommandStart
 from models.player import Player
+from datetime import datetime, timedelta
+
 from models.laboratory import Laboratory
 from models.skill import Skill
 from models.statistics import Statistics
@@ -21,6 +23,7 @@ async def cmd_start(message: types.Message):
             player=player,
             free_pathogens=10,
             max_pathogens=10,
+            next_pathogen_at=datetime.utcnow() + timedelta(minutes=60),
         )
         await Skill.create(
             lab=lab,

--- a/utils/formatting.py
+++ b/utils/formatting.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+def short_number(value: int | float) -> str:
+    value = int(value)
+    if value >= 1_000_000:
+        # e.g. 1500000 -> 1.5кк
+        if value % 1_000_000 == 0:
+            return f"{value // 1_000_000}кк"
+        else:
+            return f"{value / 1_000_000:.1f}кк"
+    elif value >= 1000:
+        if value % 1000 == 0:
+            return f"{value // 1000}к"
+        else:
+            return f"{value / 1000:.1f}к"
+    else:
+        return str(value)


### PR DESCRIPTION
## Summary
- limit qualification upgrades to level 60
- produce pathogens over time depending on qualification
- show correct time to next pathogen
- shorten large numbers in user-facing messages
- set initial timer when the lab is created

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687be062b250832a8b37473167f4e515