### PR TITLE
Add pathogen name command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -33,6 +33,8 @@ async def main():
     dp.include_router(lab_status_router)
     from handlers.lab.skills import router as lab_skills_router
     dp.include_router(lab_skills_router)
+    from handlers.lab.pathogen_name import router as pathogen_name_router
+    dp.include_router(pathogen_name_router)
     from handlers.admin import router as admin_router
     dp.include_router(admin_router)
 

--- a/handlers/lab/pathogen_name.py
+++ b/handlers/lab/pathogen_name.py
@@ -1,0 +1,24 @@
+from aiogram import Router, types, F
+import re
+from tortoise.exceptions import DoesNotExist
+from services.lab_service import get_player_cached, get_lab_cached
+
+router = Router()
+
+@router.message(F.text.regexp(r'^\.имя\s+патогена\s+.+', flags=re.IGNORECASE))
+async def set_pathogen_name(message: types.Message):
+    match = re.match(r'^\.имя\s+патогена\s+(.+)', message.text, flags=re.IGNORECASE)
+    if not match:
+        return
+    name = match.group(1).strip()
+
+    try:
+        player = await get_player_cached(message.from_user.id)
+    except DoesNotExist:
+        return await message.answer("Сначала отправьте /start, чтобы зарегистрироваться.")
+
+    lab = await get_lab_cached(player)
+    lab.pathogen_name = name
+    await lab.save()
+
+    await message.answer(f"Имя патогена установлено на <code>{name}</code>")

--- a/handlers/lab/status.py
+++ b/handlers/lab/status.py
@@ -16,7 +16,6 @@ from services.lab_service import (
 )
 from utils.formatting import short_number
 
-from models.pathogen import Pathogen
 from keyboards.lab_kb import lab_keyboard
 
 router = Router()
@@ -42,9 +41,8 @@ async def cmd_lab_status(message: types.Message):
     # update pathogen production based on current time
     await process_pathogens(lab, skills)
 
-    # 3) Берём последний созданный патоген (если был)
-    pathogen = await Pathogen.filter(lab=lab).order_by("-created_at").first()
-    pathogen_name = pathogen.name if pathogen else None
+    # 3) Имя патогена, заданное игроком
+    pathogen_name = lab.pathogen_name
 
     # 4) Данные корпорации
     if lab.corporation:

--- a/models/laboratory.py
+++ b/models/laboratory.py
@@ -21,6 +21,7 @@ class Laboratory(models.Model):
     free_pathogens   = fields.IntField(default=0)
     max_pathogens    = fields.IntField(default=0)
     next_pathogen_at = fields.DatetimeField(null=True)
+    pathogen_name    = fields.CharField(max_length=100, null=True)
 
     class Meta:
         table = "laboratories"


### PR DESCRIPTION
## Summary
- add `pathogen_name` field to `Laboratory`
- show stored pathogen name in lab status
- implement `.имя патогена` command to set pathogen name
- register new command router

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`

------
https://chatgpt.com/codex/tasks/task_e_687d07fafc68832aa3d8bc6e6c34c90d