### PR TITLE
Fix timezone awareness

### DIFF
--- a/handlers/infect.py
+++ b/handlers/infect.py
@@ -1,6 +1,6 @@
 # handlers/infect.py
 """Basic infection and vaccine purchase commands."""
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import re
 
 from aiogram import Router, types, F
@@ -33,7 +33,7 @@ async def infect_user(message: types.Message):
     attacker_stats = await get_stats_cached(attacker_lab)
     await process_pathogens(attacker_lab, await get_skill_cached(attacker_lab))
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     if attacker_lab.fever_until and attacker_lab.fever_until > now:
         return await message.answer(
             "Вы не можете заражать других, пока у вас горячка. Используйте !купить вакцину."
@@ -126,7 +126,7 @@ async def buy_vaccine(message: types.Message):
     lab = await get_lab_cached(player)
     stats = await get_stats_cached(lab)
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     if not lab.fever_until or lab.fever_until <= now:
         return await message.answer("📝 У вас нет горячки. Нет необходимости покупать вакцину")
 

--- a/handlers/lab/status.py
+++ b/handlers/lab/status.py
@@ -1,7 +1,7 @@
 # handlers/lab/status.py
 
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 
 from aiogram import Router, types, F
 from aiogram.filters import Command
@@ -60,7 +60,7 @@ async def cmd_lab_status(message: types.Message):
 
     # 6) До нового патогена
     if lab.next_pathogen_at:
-        delta = lab.next_pathogen_at - datetime.utcnow()
+        delta = lab.next_pathogen_at - datetime.now(timezone.utc)
         mins = max(0, int(delta.total_seconds() // 60))
     else:
         mins = 0

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -2,7 +2,7 @@
 from aiogram import Router, types
 from aiogram.filters import CommandStart
 from models.player import Player
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from models.laboratory import Laboratory
 from models.skill import Skill
@@ -23,7 +23,7 @@ async def cmd_start(message: types.Message):
             player=player,
             free_pathogens=10,
             max_pathogens=10,
-            next_pathogen_at=datetime.utcnow() + timedelta(minutes=60),
+            next_pathogen_at=datetime.now(timezone.utc) + timedelta(minutes=60),
         )
         await Skill.create(
             lab=lab,

--- a/models/pathogen.py
+++ b/models/pathogen.py
@@ -5,7 +5,7 @@ class Pathogen(models.Model):
     id          = fields.IntField(pk=True)
     lab         = fields.ForeignKeyField("models.Laboratory", related_name="pathogens")
     name        = fields.CharField(max_length=100, null=True)
-    created_at  = fields.DatetimeField(auto_now_add=True)
+    created_at  = fields.DatetimeField(auto_now_add=True, timezone=True)
 
     class Meta:
         table = "pathogens"

--- a/models/player.py
+++ b/models/player.py
@@ -6,7 +6,7 @@ class Player(models.Model):
     telegram_id = fields.BigIntField(unique=True)
     username     = fields.CharField(max_length=32, null=True)
     full_name    = fields.CharField(max_length=255, null=True)
-    created_at   = fields.DatetimeField(auto_now_add=True)
+    created_at   = fields.DatetimeField(auto_now_add=True, timezone=True)
 
     class Meta:
         table = "players"

--- a/services/lab_service.py
+++ b/services/lab_service.py
@@ -59,7 +59,7 @@ async def get_stats_cached(lab: Laboratory) -> Statistics:
     _stats_cache[lab.id] = (stats, now + _CACHE_TTL)
     return stats
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 def pathogen_interval(qualification: int) -> int:
@@ -69,7 +69,7 @@ def pathogen_interval(qualification: int) -> int:
 
 async def process_pathogens(lab: Laboratory, skills: Skill) -> None:
     """Update lab.free_pathogens based on timers and skills."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     interval = pathogen_interval(skills.qualification)
 
     if lab.free_pathogens >= lab.max_pathogens:


### PR DESCRIPTION
## Summary
- ensure datetime fields use timezone=True
- use timezone-aware datetime operations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e8f7fe8a8832a8b79114450dd14c4