### PR TITLE
Implement infection cooldown

### DIFF
--- a/handlers/infect.py
+++ b/handlers/infect.py
@@ -1,6 +1,7 @@
 # handlers/infect.py
 """Basic infection and vaccine purchase commands."""
 from datetime import datetime, timedelta, timezone
+from typing import Dict, Tuple
 import re
 
 from aiogram import Router, types, F
@@ -17,6 +18,9 @@ from models.player import Player
 from utils.formatting import short_number
 
 router = Router()
+
+# ключ – (attacker_id, target_id), значение – время последнего заражения
+_infection_cd: Dict[Tuple[int, int], datetime] = {}
 
 
 @router.message(F.text.regexp(r'^заразить', flags=re.IGNORECASE))
@@ -64,6 +68,17 @@ async def infect_user(message: types.Message):
     if target_user.id == attacker_id:
         return await message.answer("Нельзя заразить себя")
 
+    cooldown_key = (attacker_id, target_user.id)
+    last_attack = _infection_cd.get(cooldown_key)
+    if last_attack and now - last_attack < timedelta(hours=3):
+        remaining = timedelta(hours=3) - (now - last_attack)
+        minutes = int(remaining.total_seconds() // 60)
+        hours = minutes // 60
+        minutes %= 60
+        return await message.answer(
+            f"Повторное заражение этого пользователя будет доступно через {hours} ч. {minutes} мин."
+        )
+
     target_player, _ = await Player.get_or_create(
         telegram_id=target_user.id,
         defaults={"full_name": target_user.full_name},
@@ -88,8 +103,14 @@ async def infect_user(message: types.Message):
     attacker_link = f"<a href=\"tg://openmessage?user_id={attacker_id}\">{message.from_user.full_name}</a>"
     target_link = f"<a href=\"tg://openmessage?user_id={target_user.id}\">{target_user.full_name}</a>"
 
+    pathogen_name = attacker_lab.pathogen_name
+    if pathogen_name:
+        pathogen_phrase = f"патогеном «{pathogen_name}»"
+    else:
+        pathogen_phrase = "неизвестным патогеном"
+
     text = (
-        f"🦠 {attacker_link} подверг заражению неизвестным патогеном {target_link}\n"
+        f"🦠 {attacker_link} подверг заражению {pathogen_phrase} {target_link}\n"
         f"☠️ Горячка на {fever_minutes} минут\n"
         f"🤒 Заражение на {infection_days} дней\n"
         f"☣️ +1k био-опыта"
@@ -103,7 +124,7 @@ async def infect_user(message: types.Message):
                 "🕵️‍♂️ Служба безопасности Вашей лаборатории докладывает:\n"
                 "Была произведена как минимум 1 попытка Вашего заражения\n"
                 f"Организатор заражения: {attacker_link}\n\n"
-                f"<blockquote>🦠 {attacker_link} подверг заражению патогеном «Autumn symphony» {target_link}⁬\n"
+                f"<blockquote>🦠 {attacker_link} подверг заражению {pathogen_phrase} {target_link}⁬\n"
                 f"☠️ Горячка на {fever_minutes} минут\n"
                 f"🤒 Заражение на {infection_days} дней\n"
                 f"☣️ +263 био-опыта</blockquote>"
@@ -112,6 +133,8 @@ async def infect_user(message: types.Message):
         )
     except Exception:
         pass
+
+    _infection_cd[cooldown_key] = now
 
 
 @router.message(F.text.regexp(r'^!купить\s+вакцину$', flags=re.IGNORECASE))


### PR DESCRIPTION
## Summary
- add per-target cooldown dictionary
- use pathogen name instead of fixed string
- inform attacker of remaining cooldown period

## Testing
- `python -m py_compile handlers/infect.py`

------
https://chatgpt.com/codex/tasks/task_e_688277d03d60832a9d76c2508c44835c