### PR TITLE
Add cooldown middleware and auto-register players

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,6 +5,8 @@ from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
+
+from middlewares.cooldown import CooldownMiddleware
 from tortoise import Tortoise
 
 from config import settings  # config.py должно использовать pydantic-settings
@@ -25,6 +27,7 @@ async def main():
         ),
     )
     dp = Dispatcher(storage=MemoryStorage())
+    dp.message.middleware.register(CooldownMiddleware(1.0))
 
     # Регистрируем все роутеры
     from handlers.start import router as start_router

--- a/handlers/infect.py
+++ b/handlers/infect.py
@@ -79,6 +79,9 @@ async def infect_user(message: types.Message):
             f"Повторное заражение этого пользователя будет доступно через {hours} ч. {minutes} мин."
         )
 
+    # фиксируем время заражения сразу, чтобы избежать спама
+    _infection_cd[cooldown_key] = now
+
     target_player, _ = await Player.get_or_create(
         telegram_id=target_user.id,
         defaults={"full_name": target_user.full_name},
@@ -134,7 +137,6 @@ async def infect_user(message: types.Message):
     except Exception:
         pass
 
-    _infection_cd[cooldown_key] = now
 
 
 @router.message(F.text.regexp(r'^!купить\s+вакцину$', flags=re.IGNORECASE))

--- a/handlers/lab/status.py
+++ b/handlers/lab/status.py
@@ -5,14 +5,13 @@ from datetime import datetime, timezone
 
 from aiogram import Router, types, F
 from aiogram.filters import Command
-from tortoise.exceptions import DoesNotExist
-
 from services.lab_service import (
     get_player_cached,
     get_lab_cached,
     get_skill_cached,
     get_stats_cached,
     process_pathogens,
+    register_player_if_needed,
 )
 from utils.formatting import short_number
 
@@ -27,11 +26,11 @@ router = Router()
 async def cmd_lab_status(message: types.Message):
     user_id = message.from_user.id
 
-    # 1) Проверка, что игрок есть
-    try:
-        player = await get_player_cached(user_id)
-    except DoesNotExist:
-        return await message.answer("Сначала отправьте /start, чтобы зарегистрироваться.")
+    # 1) Проверка/создание игрока и лаборатории
+    player = await register_player_if_needed(
+        user_id,
+        message.from_user.full_name,
+    )
 
     # 2) Загружаем лабораторию + связи
     lab = await get_lab_cached(player)

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -1,39 +1,17 @@
 # handlers/start.py
 from aiogram import Router, types
 from aiogram.filters import CommandStart
-from models.player import Player
-from datetime import datetime, timedelta, timezone
-
-from models.laboratory import Laboratory
-from models.skill import Skill
-from models.statistics import Statistics
+from services.lab_service import register_player_if_needed
 
 router = Router()
 
 @router.message(CommandStart())
 async def cmd_start(message: types.Message):
-    # Регистрируем игрока, если надо
-    player, created = await Player.get_or_create(
-        telegram_id=message.from_user.id,
-        defaults={"full_name": message.from_user.full_name},
+    # Регистрируем игрока и лабораторию при первом запуске
+    await register_player_if_needed(
+        message.from_user.id,
+        message.from_user.full_name,
     )
-    if created:
-        # Создаём лабораторию с начальными данными + связанные записи
-        lab = await Laboratory.create(
-            player=player,
-            free_pathogens=10,
-            max_pathogens=10,
-            next_pathogen_at=datetime.now(timezone.utc) + timedelta(minutes=60),
-        )
-        await Skill.create(
-            lab=lab,
-            infectivity=1,
-            immunity=1,
-            lethality=1,
-            safety=1,
-            qualification=1,
-        )
-        await Statistics.create(lab=lab)
 
     # Приветственный текст
     welcome_text = (

--- a/middlewares/cooldown.py
+++ b/middlewares/cooldown.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict
+
+from aiogram import types
+from aiogram.dispatcher.middlewares.base import BaseMiddleware
+
+
+class CooldownMiddleware(BaseMiddleware):
+    """Simple per-user cooldown for message processing."""
+
+    def __init__(self, delay: float = 1.0) -> None:
+        self.delay = delay
+        self._last_call: Dict[int, datetime] = {}
+
+    async def __call__(self, handler, event, data):
+        if isinstance(event, types.Message):
+            user_id = event.from_user.id
+        else:
+            return await handler(event, data)
+
+        now = datetime.now(timezone.utc)
+        last_time = self._last_call.get(user_id)
+        if last_time and (now - last_time).total_seconds() < self.delay:
+            return  # ignore message to prevent spam
+
+        self._last_call[user_id] = now
+        return await handler(event, data)


### PR DESCRIPTION
## Summary
- add a cooldown middleware to block repeated commands during 1 second
- auto register players when calling `/start` and lab status
- expose helper `register_player_if_needed`
- set infection cooldown earlier to prevent spam

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6882868361e0832aa4aea3c06b3981d2