### PR TITLE
Implement lab naming and mini lab

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -38,6 +38,10 @@ async def main():
     dp.include_router(lab_skills_router)
     from handlers.lab.pathogen_name import router as pathogen_name_router
     dp.include_router(pathogen_name_router)
+    from handlers.lab.lab_name import router as lab_name_router
+    dp.include_router(lab_name_router)
+    from handlers.lab.minilab import router as minilab_router
+    dp.include_router(minilab_router)
     from handlers.admin import router as admin_router
     dp.include_router(admin_router)
     from handlers.infect import router as infect_router

--- a/handlers/infect.py
+++ b/handlers/infect.py
@@ -153,14 +153,14 @@ async def buy_vaccine(message: types.Message):
 
     now = datetime.now(timezone.utc)
     if not lab.fever_until or lab.fever_until <= now:
-        return await message.answer("📝 У вас нет горячки. Нет необходимости покупать вакцину")
+        return await message.answer("<b>📝 У вас нет горячки.</b>")
 
     seconds_left = int((lab.fever_until - now).total_seconds())
     price_per_second = 2000 / (60 * 60)
     cost = max(0, int(price_per_second * seconds_left))
 
     if cost > stats.bio_resource:
-        return await message.answer("Недостаточно био-ресурсов")
+        return await message.answer("<b>❌ Не хватает био-ресурсов на вакцину.</b>")
 
     stats.bio_resource -= cost
     await stats.save()
@@ -169,5 +169,6 @@ async def buy_vaccine(message: types.Message):
     await lab.save()
 
     await message.answer(
-        f"💉 Вакцина излечила вас от горячки.\n🧾 Потрачено 🧬 {short_number(cost)} био-ресурсов"
+        f"💉 <b>Вы излечились от горячки.</b>\n"
+        f"🧬 <b>Стоимость вакцины</b> : <code>{short_number(cost)}</code> био-ресурсов"
     )

--- a/handlers/lab/lab_name.py
+++ b/handlers/lab/lab_name.py
@@ -1,0 +1,47 @@
+from aiogram import Router, types, F
+import re
+from tortoise.exceptions import DoesNotExist
+
+from services.lab_service import get_player_cached, get_lab_cached
+from models.laboratory import Laboratory
+
+router = Router()
+
+@router.message(F.text.regexp(r'^-лаб$', flags=re.IGNORECASE))
+async def clear_lab_name(message: types.Message):
+    try:
+        player = await get_player_cached(message.from_user.id)
+    except DoesNotExist:
+        return await message.answer("Сначала отправьте /start, чтобы зарегистрироваться.")
+
+    lab = await get_lab_cached(player)
+    lab.lab_name = None
+    await lab.save()
+
+    await message.answer("❎ Название лаборатории удалено")
+
+
+@router.message(F.text.regexp(r'^\.имя\s+лабы\s+.+', flags=re.IGNORECASE))
+async def set_lab_name(message: types.Message):
+    match = re.match(r'^\.имя\s+лабы\s+(.+)$', message.text, flags=re.IGNORECASE)
+    if not match:
+        return
+
+    name = match.group(1).strip()
+    if len(name) > 30:
+        return await message.answer("❌ Имя лаборатории должно быть не длиннее 30 символов.")
+
+    try:
+        player = await get_player_cached(message.from_user.id)
+    except DoesNotExist:
+        return await message.answer("Сначала отправьте /start, чтобы зарегистрироваться.")
+
+    exists = await Laboratory.filter(lab_name__iexact=name).exists()
+    if exists:
+        return await message.answer("🗓 Такое имя лаборатории уже существует!")
+
+    lab = await get_lab_cached(player)
+    lab.lab_name = name
+    await lab.save()
+
+    await message.answer("<b>✅ Имя лаборатории обновлено.</b>")

--- a/handlers/lab/minilab.py
+++ b/handlers/lab/minilab.py
@@ -1,0 +1,38 @@
+from aiogram import Router, types, F
+import re
+from services.lab_service import (
+    register_player_if_needed,
+    get_lab_cached,
+    get_stats_cached,
+    get_skill_cached,
+    process_pathogens,
+)
+from utils.formatting import short_number
+
+router = Router()
+
+@router.message(
+    F.text.regexp(r'^[/.]?(?:минилаб|млаб|мл)$', flags=re.IGNORECASE)
+)
+async def cmd_minilab(message: types.Message):
+    user_id = message.from_user.id
+
+    player = await register_player_if_needed(
+        user_id,
+        message.from_user.full_name,
+    )
+
+    lab = await get_lab_cached(player)
+    stats = await get_stats_cached(lab)
+    await process_pathogens(lab, await get_skill_cached(lab))
+
+    display_name = lab.lab_name or message.from_user.full_name
+
+    text = (
+        f"<b>🔬 Лаборатория:</b> "
+        f"<a href=\"tg://openmessage?user_id={user_id}\">{display_name}</a>\n"
+        f"<blockquote>🧪 Свободных патогенов: {short_number(lab.free_pathogens)} из {short_number(lab.max_pathogens)}\n"
+        f"☢️ Био‑опыт: {short_number(stats.bio_experience)}\n"
+        f"🧬 Био‑ресурс: {short_number(stats.bio_resource)}</blockquote>"
+    )
+    await message.answer(text)

--- a/handlers/lab/status.py
+++ b/handlers/lab/status.py
@@ -73,9 +73,10 @@ async def cmd_lab_status(message: types.Message):
         blocked_pct = "0%"
 
     # 8) HTML‑текст
+    display_name = lab.lab_name or message.from_user.full_name
     text = (
         f"<b>🔬 Лаборатория игрока:</b> "
-        f"<a href=\"tg://openmessage?user_id={user_id}\">{message.from_user.full_name}</a>\n"
+        f"<a href=\"tg://openmessage?user_id={user_id}\">{display_name}</a>\n"
         f"{corp_line}\n"
 
         f"<b>🪫 Активность: [{blocks}] {lab.activity}%</b>\n"

--- a/models/laboratory.py
+++ b/models/laboratory.py
@@ -20,6 +20,7 @@ class Laboratory(models.Model):
     free_pathogens     = fields.IntField(default=0)
     max_pathogens      = fields.IntField(default=0)
     pathogen_name      = fields.CharField(max_length=100, null=True)
+    lab_name           = fields.CharField(max_length=30, null=True)
 
     class Meta:
         table = "laboratories"

--- a/services/lab_service.py
+++ b/services/lab_service.py
@@ -99,11 +99,13 @@ async def register_player_if_needed(tg_id: int, full_name: str) -> Player:
 
     if created:
         now = datetime.now(timezone.utc)
+        default_name = f"им. {full_name}"[:30]
         lab = await Laboratory.create(
             player=player,
             free_pathogens=10,
             max_pathogens=10,
             next_pathogen_at=now + timedelta(minutes=60),
+            lab_name=default_name,
         )
         await Skill.create(
             lab=lab,


### PR DESCRIPTION
## Summary
- add `lab_name` field in Laboratory model with default name on player creation
- implement commands `.имя лабы`, `-лаб`, and short `минилаб` status
- update vaccine messages
- show lab name in lab status
- register new routers in bot startup

## Testing
- `python -m py_compile bot.py handlers/infect.py handlers/lab/status.py handlers/lab/minilab.py handlers/lab/lab_name.py models/laboratory.py services/lab_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68828c2a21ac832a8164ad656c299034